### PR TITLE
refactor: remove unused DATABRICKS_VERSION parameter

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,6 @@ jobs:
             tag: 15.4-LTS
             context: ./src/revo-devcontainer-databricks
             python_version: 3.11.11
-            databricks_version: 15.4-LTS
             platforms: linux/amd64,linux/arm64
           - name: revo-devcontainer-databricks
             dockerfile: ./src/revo-devcontainer-databricks/Dockerfile
@@ -28,7 +27,6 @@ jobs:
             additional_tags: latest
             context: ./src/revo-devcontainer-databricks
             python_version: 3.12.4
-            databricks_version: 16.4-LTS
             platforms: linux/amd64,linux/arm64
           - name: revo-devcontainer-slim
             dockerfile: ./src/revo-devcontainer-slim/Dockerfile
@@ -71,7 +69,6 @@ jobs:
           push: true
           build-args: |
             PYTHON_VERSION=${{ matrix.image.python_version }}
-            DATABRICKS_VERSION=${{ matrix.image.databricks_version }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image.name }}:${{ matrix.image.tag }}
             ${{ matrix.image.additional_tags && format('ghcr.io/{0}/{1}:{2}', github.repository_owner, matrix.image.name, matrix.image.additional_tags) || '' }}
@@ -87,6 +84,4 @@ jobs:
           fi
           echo "  🏗️  Built for platforms: ${{ matrix.image.platforms }}"
           echo "  🐍 Python version: ${{ matrix.image.python_version }}"
-          if [[ -n "${{ matrix.image.databricks_version }}" ]]; then
-            echo "  🧱 Databricks version: ${{ matrix.image.databricks_version }}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
             tag: 15.4-LTS
             context: ./src/revo-devcontainer-databricks
             python_version: 3.11.11
-            databricks_version: 15.4-LTS
             platforms: linux/amd64
 
           - name: revo-devcontainer-databricks
@@ -27,7 +26,6 @@ jobs:
             tag: 16.4-LTS
             context: ./src/revo-devcontainer-databricks
             python_version: 3.12.4
-            databricks_version: 16.4-LTS
             platforms: linux/amd64
 
           - name: revo-devcontainer-slim
@@ -58,7 +56,6 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           build-args: |
             PYTHON_VERSION=${{ matrix.image.python_version }}
-            DATABRICKS_VERSION=${{ matrix.image.databricks_version }}
           tags: ${{ matrix.image.name }}:${{ matrix.image.tag }}
           cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.image.tag }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-${{ matrix.image.tag }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,11 @@ The project uses a comprehensive Makefile for container operations:
 
 ```bash
 # Build specific container variants with parameters
-make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4 DATABRICKS_VERSION=16.4-LTS
+make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4
 make build CONTAINER=revo-devcontainer-slim TAG=3.12.4-slim PYTHON_VERSION=3.12.4
 
 # Build, tag and push (requires CR_PAT environment variable)
-make all CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4 DATABRICKS_VERSION=16.4-LTS
+make all CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4
 
 # Build for single architecture (default is multi-arch)
 make build MULTI_ARCH=false CONTAINER=revo-devcontainer-slim TAG=3.11.11-slim
@@ -70,7 +70,6 @@ All containers use multi-stage builds with parameterized base images:
 ### Parameterized Build Arguments
 
 - **PYTHON_VERSION**: Python version to install (e.g., `3.11.11`, `3.12.4`)
-- **DATABRICKS_VERSION**: Databricks Runtime version (e.g., `15.4-LTS`, `16.4-LTS`)
 
 ### Key Environment Variables
 
@@ -128,7 +127,7 @@ The project uses GitHub Actions with three workflows:
 2. Test locally using parameterized builds:
 
    ```bash
-   make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4 DATABRICKS_VERSION=16.4-LTS
+   make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4
    make shell CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS
    ```
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ All containers are built for both `linux/amd64` and `linux/arm64` architectures,
 
 ```bash
 # Build specific container variants with parameters
-make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4 DATABRICKS_VERSION=16.4-LTS
+make build CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4
 make build CONTAINER=revo-devcontainer-slim TAG=3.12.4-slim PYTHON_VERSION=3.12.4
 
 # Build, tag and push (requires CR_PAT environment variable)
-make all CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4 DATABRICKS_VERSION=16.4-LTS
+make all CONTAINER=revo-devcontainer-databricks TAG=16.4-LTS PYTHON_VERSION=3.12.4
 
 # Build for single architecture (default is multi-arch)
 make build MULTI_ARCH=false CONTAINER=revo-devcontainer-slim TAG=3.11.11-slim


### PR DESCRIPTION
## Summary
- Remove unused DATABRICKS_VERSION parameter from CI/CD workflows
- Clean up documentation references to the removed parameter
- Simplify build process by removing redundant build argument

## Test plan
- [ ] Verify CI builds pass without DATABRICKS_VERSION parameter
- [ ] Confirm all container variants build successfully
- [ ] Test that documentation examples work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)